### PR TITLE
feat: pfe-clipboard & adding lerna link to generator

### DIFF
--- a/elements/pfe-clipboard/README.md
+++ b/elements/pfe-clipboard/README.md
@@ -1,0 +1,152 @@
+# PatternFly Element | Clipboard element
+
+A button to copy the current URL to the system clipboard.
+
+## Usage
+
+### Default
+```html
+<pfe-clipboard role="button" tabindex="0"></pfe-clipboard>
+```
+
+### Optionally hide the icon
+```html
+<pfe-clipboard no-icon role="button" tabindex="0"></pfe-clipboard>
+```
+
+### Override the link text
+```html
+<pfe-clipboard role="button" tabindex="0">
+    <span slot="text">hey you, copy this url!</span>
+</pfe-clipboard>
+```
+
+### Override the copied notification text
+```html
+<pfe-clipboard role="button" tabindex="0">
+    <span slot="text--success">URL Copied to clipboard</span>
+</pfe-clipboard>
+```
+### Override the icon
+```html
+<pfe-clipboard role="button" tabindex="0">
+    <pfe-icon slot="icon" icon="web-icon-globe"></pfe-icon>
+</pfe-clipboard>
+```
+
+## Override all slots
+```html
+<pfe-clipboard role="button" tabindex="0">
+    <span slot="text">Copy this article URL</span>
+    <span slot="text--success">URL Copied to clipboard</span>
+    <pfe-icon slot="icon" icon="web-icon-globe"></pfe-icon>
+</pfe-clipboard>
+```
+
+## Specify the amount of seconds the copy success text should be visible
+```html
+<pfe-clipboard role="button" tabindex="0" copied-duration="5"></pfe-clipboard>
+```
+
+### Accessibility
+
+`<pfe-clipboard>` implements many features of a standard button to provide an accessible
+experience for all users. By default, `role="button"` and `tabindex="0"` are added to
+inform assistive technology that `<pfe-clipboard>` should be treated as a button.  It listens for
+mouse clicks as well as enter and space key presses per the recommendation of
+[w3.org](https://www.w3.org/TR/wai-aria-practices-1.1/examples/button/button.html).
+
+## Slots
+
+- `text`: Optionally override the text of the button.
+
+- `icon`: Optionally override the default link svg icon. You can inline svg `<svg slot="icon"></svg>` or use pfe-icon `<pfe-icon slot="icon" icon="web-icon-globe"></pfe-icon>`.
+
+- `text--success`: Optionally override the text of the success state which defaults to `Copied`.
+
+## Attributes
+
+- `no-icon`: Optional boolean attribute that, when present, removes the icon from the template.
+- `copied-duration`: Specify the amount of time in seconds the copy success text should be visible.
+
+## Variable hooks
+
+Available hooks for styling:
+
+| Variable name | Default value | Region |
+| --- | --- | --- |
+| `--pfe-clipboard--Color` | `var(--pfe-broadcasted--link, #06c)` | N/A |
+| `--pfe-clipboard--FontWeight` | `var(--pfe-theme--font-weight--light, 300)` | N/A |
+| `--pfe-clipboard--FontSize` | `1rem` | N/A |
+| `--pfe-clipboard--Padding` | `6px 16px` | N/A |
+| `--pfe-clipboard--icon--Width` | `16px` | `icon` |
+| `--pfe-clipboard--icon--Height` | `auto` | `icon` |
+| `--pfe-clipboard--icon--margin` | `0 0.4825rem 0 0` | `icon` |
+| `--pfe-clipboard--icon--Color` | `#6a6e73` | `icon` |
+| `--pfe-clipboard--Color--focus` | `var(--pfe-broadcasted--link--focus, #004080)` | N/A |
+| `--pfe-clipboard--Color--hover` | `var(--pfe-broadcasted--link--hover, #004080)` | N/A |
+
+## Events
+Describe any events that are accessible external to the web component. There is no need to describe all the internal-only functions.
+
+### pfe-clipboard:copied
+
+Fires when the current url is successfully copied the user's system clipboard.
+
+```
+detail: {
+    url: String
+}
+```
+
+## API
+
+### copyURLToClipboard()
+
+Copy url to the user's system clipboard
+
+If available, it will use the new Navigator API to access the system clipboard
+https://developer.mozilla.org/en-US/docs/Web/API/Navigator/clipboard
+
+If unavailable, it will use the legacy execCommand("copy")
+https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand
+
+#### Returns
+
+- `Promise<string>` url
+
+```js
+document.querySelector("pfe-clipboard").copyURLToClipboard()
+    .then(url => console.log(`Successfully copied: ${url}`))
+    .catch(error => console.error(error));
+```
+
+## Dependencies
+
+None.
+
+## Dev
+
+    `npm start`
+
+## Test
+
+    `npm run test`
+
+## Build
+
+    `npm run build`
+
+## Demo
+
+From the PFElements root directory, run:
+
+    `npm run demo`
+
+## Code style
+
+Clipboard (and all PFElements) use [Prettier][prettier] to auto-format JS and JSON. The style rules get applied when you commit a change. If you choose to, you can [integrate your editor][prettier-ed] with Prettier to have the style rules applied on every save.
+
+[prettier]: https://github.com/prettier/prettier/
+[prettier-ed]: https://prettier.io/docs/en/editors.html
+[web-component-tester]: https://github.com/Polymer/web-component-tester

--- a/elements/pfe-clipboard/build.js
+++ b/elements/pfe-clipboard/build.js
@@ -1,0 +1,6 @@
+import build from "../../scripts/build.js";
+
+build({
+  entryPoints: ["src/pfe-clipboard.ts"],
+  outdir: "dist",
+});

--- a/elements/pfe-clipboard/demo/index.html
+++ b/elements/pfe-clipboard/demo/index.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>pfe-clipboard</title>
+  <link rel="stylesheet" href="/elements/pfelement/dist/pfelement.css">
+  <script type="module" src="/elements/pfe-clipboard/dist/pfe-clipboard.js"></script>
+</head>
+<body unresolved>
+  <pfe-band color="lightest">
+    <h1 slot="pfe-band--header">&#x3C;pfe-clipboard&#x3E;</h1>
+    <p>This element embeds a copy url button on your site.</p>
+
+    <h2>Clipboard</h2>
+    <pfe-clipboard role="button" tabindex="0"></pfe-clipboard>
+
+    <h2>Clipboard with no icon</h2>
+    <pfe-clipboard no-icon role="button" tabindex="0"></pfe-clipboard>
+
+    <h2>Clipboard: with custom icon</h2>
+    <pfe-clipboard role="button" tabindex="0">
+      <pfe-icon slot="icon" icon="web-icon-globe"></pfe-icon>
+    </pfe-clipboard>
+
+    <h2>Clipboard: with custom text</h2>
+    <pfe-clipboard role="button" tabindex="0">
+      <span slot="text">You can totally click to copy url</span>
+      <span slot="text--success">Making some copies!</span>
+    </pfe-clipboard>
+
+    <h2>Clipboard: with custom success text duration.</h2>
+    <pfe-clipboard role="button" tabindex="0" copied-duration="5"></pfe-clipboard>
+  </pfe-band>
+
+  <pfe-band color="darkest">
+    <p>This element embeds a copy url button on your site.</p>
+
+    <h2>Clipboard</h2>
+    <pfe-clipboard role="button" tabindex="0"></pfe-clipboard>
+
+    <h2>Clipboard with no icon</h2>
+    <pfe-clipboard no-icon role="button" tabindex="0"></pfe-clipboard>
+
+    <h2>Clipboard: with custom icon</h2>
+    <pfe-clipboard role="button" tabindex="0">
+      <pfe-icon slot="icon" icon="web-icon-globe"></pfe-icon>
+    </pfe-clipboard>
+
+    <h2>Clipboard: with custom text</h2>
+    <pfe-clipboard role="button" tabindex="0">
+      <span slot="text">You can totally click to copy url</span>
+      <span slot="text--success">Making some copies!</span>
+    </pfe-clipboard>
+
+    <h2>Clipboard: with custom success text duration.</h2>
+    <pfe-clipboard role="button" tabindex="0" copied-duration="5"></pfe-clipboard>
+  </pfe-band>
+</body>
+</html>

--- a/elements/pfe-clipboard/package.json
+++ b/elements/pfe-clipboard/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@patternfly/pfe-clipboard",
+  "version": "2.0.0",
+  "description": "Clipboard element for PatternFly Elements",
+  "type": "module",
+  "main": "dist/pfe-clipboard",
+  "module": "dist/pfe-clipboard",
+  "directories": {
+    "test": "tests"
+  },
+  "scripts": {
+    "build": "node build.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@patternfly/pfelement": "^2.0.0",
+    "lit": "^2.0.0-rc.2"
+  },
+  "devDependencies": {
+    "@patternfly/pfe-sass": "^1.10.1"
+  }
+}

--- a/elements/pfe-clipboard/src/pfe-clipboard.scss
+++ b/elements/pfe-clipboard/src/pfe-clipboard.scss
@@ -1,0 +1,104 @@
+// Please see the pfe-sass README for guidance on using these tools
+@import "../../pfe-sass/pfe-sass";
+
+$LOCAL: clipboard;
+
+// This variable is global so that helper functions can reference it
+$LOCAL-VARIABLES: (
+  Padding: 6px 16px,
+  FontWeight: pfe-var(font-weight--light),
+  Color: pfe-broadcasted(link),
+  Color--hover: pfe-broadcasted(link--hover),
+  Color--focus: pfe-broadcasted(link--focus),
+  text--success--Color: pfe-var(feedback--success),
+  icon--Width: pfe-var(icon-size),
+  icon--Height: auto,
+  icon--Margin: 0 0.4825rem 0 0, // 7.72px
+  icon--Color: pfe-var(text--muted)
+);
+
+:host {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  max-width: fit-content;
+  color: pfe-local(Color) !important;
+  cursor: pointer;
+  padding: pfe-local(Padding);
+  font-weight: pfe-local(FontWeight);
+  @include pfe-c-typography($type: text, $sizing: md);
+}
+
+:host([hidden]) {
+  display: none;
+}
+
+//-- Custom styles applied to slot's shadow element
+.pfe-clipboard {
+  &__icon {
+    display: flex;
+    width: pfe-local(icon--Width);
+    // This is needed if the icon isn't square
+    height: pfe-local(icon--Height);
+    margin: pfe-local(icon--Margin);
+    // Customize icon color for pfe-icons
+    --pfe-icon--Color: #{pfe-local(icon--Color)};
+    svg {
+      // Customize icon color of fallback svg icon
+      fill: pfe-local(icon--Color) !important;
+    }
+  }
+  &__text {
+    color: pfe-local(Color) !important;
+  }
+
+  &__text--success {
+    color: pfe-local(text--success--Color) !important;
+  }
+}
+
+// Flipped clipboard text and success text
+:host([copied]) .pfe-clipboard__text,
+.pfe-clipboard[copied] .pfe-clipboard__text {
+  display: none !important;
+}
+:host(:not([copied])) .pfe-clipboard__text--success,
+.pfe-clipboard:not([copied]) .pfe-clipboard__text--success {
+  display: none !important;
+}
+
+//-- Custom styles applied to slot
+// Targets icon in the shadowdom and lightdom
+::slotted([slot="icon"]),
+.pfe-clipboard__icon > * {
+  width: 100%;
+}
+
+// Note: Focus states need to be defined before hover states
+:host(:not([aria-disabled="true"]):focus),
+:host(:not([aria-disabled="true"]).focus-within) {
+  --pfe-clipboard--Color: #{pfe-local(Color--focus)};
+}
+
+// Note: Hover states need to be defined after focus states
+:host(:not([aria-disabled="true"]):hover),
+:host(:not([aria-disabled="true"])) ::slotted(:hover) {
+  --pfe-clipboard--Color: #{pfe-local(Color--hover)};
+}
+
+@include browser-query(ie11) {
+  :host {
+    // fallback for inline-flex
+    display: inline-block;
+  }
+  .pfe-clipboard__icon {
+    display: inline-block;
+    margin-right: 0;
+  }
+  .pfe-clipboard__text {
+    display: inline-block;
+  }
+  .pfe-clipboard__text--success {
+    display: inline-block;
+  }
+}

--- a/elements/pfe-clipboard/src/pfe-clipboard.ts
+++ b/elements/pfe-clipboard/src/pfe-clipboard.ts
@@ -1,0 +1,205 @@
+import { PFElement, html } from "@patternfly/pfelement";
+import styles from "pfe-clipboard.scss";
+
+export class PfeClipboard extends PFElement {
+  static styles = styles;
+
+  static get tag() {
+    return "pfe-clipboard";
+  }
+
+  static get meta() {
+    return {
+      title: "Clipboard",
+      description: "Copy current URL to clipboard.",
+    };
+  }
+
+  static get events() {
+    return {
+      copied: `${this.tag}:copied`,
+    };
+  }
+
+  // Declare the type of this component
+  static get PfeType() {
+    return PFElement.PfeTypes.Content;
+  }
+
+  static get slots() {
+    return {
+      icon: {
+        title: "Icon",
+        description: "This field can accept an SVG, pfe-icon component, or other format for displaying an icon.",
+        slotName: "icon",
+        slotClass: "pfe-clipboard__icon",
+        slotId: "icon",
+      },
+      text: {
+        title: "Default text",
+        slotName: "text",
+        slotClass: "pfe-clipboard__text",
+        slotId: "text",
+      },
+      textSuccess: {
+        title: "Success message",
+        description: "Shown when the URL is successfully copied to the clipboard.",
+        slotName: "text--success",
+        slotClass: "pfe-clipboard__text--success",
+        slotId: "text--success",
+      },
+    };
+  }
+
+  static get properties() {
+    return {
+      noIcon: {
+        title: "No icon",
+        type: Boolean,
+      },
+      copiedDuration: {
+        title: "Success message duration (in seconds)",
+        type: Number,
+      },
+      role: {
+        type: String,
+      },
+      tabindex: {
+        type: Number,
+      },
+    };
+  }
+
+  constructor() {
+    super();
+    this.noIcon = false;
+    this.copiedDuration = 3;
+    this.copiedDuration = 3;
+    this.role = 'button';
+    this.tabindex = 0;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    // Since this element as the role of button we are going to listen
+    // for click and as well as 'enter' and 'space' commands to trigger
+    // the copy functionality
+    this.addEventListener("click", this._clickHandler.bind(this));
+    this.addEventListener("keydown", this._keydownHandler.bind(this));
+  }
+
+  disconnectedCallback() {
+    this.removeEventListener("click", this._clickHandler.bind(this));
+    this.removeEventListener("keydown", this._keydownHandler.bind(this));
+    this.shadowRoot.removeEventListener("slotchange", this._slotchangeHandler.bind(this));
+    super.disconnectedCallback();
+  }
+
+  _clickHandler(event) {
+    // Execute the copy to clipboard functionality
+    this.copyURLToClipboard()
+      .then((url) => {
+        // Emit event that lets others know the user has "copied"
+        // the url. We are also going to include the url that was
+        // copied.
+        this.emitEvent(PfeClipboard.events.copied, {
+          detail: {
+            url,
+          },
+        });
+        // Toggle the copied state. Use the this._formattedCopiedTimeout function
+        // to an appropraite setTimout length.
+        this.setAttribute("copied", "");
+        setTimeout(() => {
+          this.removeAttribute("copied");
+        }, this._formattedCopiedTimeout());
+      })
+      .catch((error) => {
+        this.warn(error);
+      });
+  }
+
+  // Formatted copied timeout value. Use the formattedCopiedTimeout function
+  // to get a type safe, millisecond value of the timeout duration.
+  _formattedCopiedTimeout() {
+    const copiedDuration = Number(this.copiedDuration * 1000);
+    if (!(copiedDuration > -1)) {
+      this.warn(`copied-duration must be a valid number. Defaulting to 3 seconds.`);
+      // default to 3 seconds
+      return 3000;
+    } else {
+      return copiedDuration;
+    }
+  }
+
+  // Listen for keyboard events and map them to their
+  // corresponding mouse events.
+  _keydownHandler(event) {
+    let key = event.key || event.keyCode;
+    switch (key) {
+      case "Enter" || 13:
+        this._clickHandler(event);
+        break;
+      case " " || 32:
+        // Prevent the browser from scolling when the user hits the space key
+        event.stopPropagation();
+        event.preventDefault();
+        this._clickHandler(event);
+        break;
+    }
+  }
+
+  /**
+   * Copy url to the user's system clipboard
+   *
+   * If available, it will use the new Navigator API to access the system clipboard
+   * https://developer.mozilla.org/en-US/docs/Web/API/Navigator/clipboard
+   *
+   * If unavailable, it will use the legacy execCommand("copy")
+   * https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand
+   * @async
+   * @return {Promise<string>} url
+   */
+  copyURLToClipboard() {
+    return new Promise((resolve, reject) => {
+      const url = window.location.href;
+      // If the Clipboard API is available then use that
+      if (navigator.clipboard) {
+        navigator.clipboard.writeText(url).then(resolve(url));
+      }
+      // If execCommand("copy") exists then use that method
+      else if (document.queryCommandEnabled("copy")) {
+        const dummy = document.createElement("input");
+        document.body.appendChild(dummy);
+        dummy.value = url;
+        dummy.select();
+        document.execCommand("copy");
+        document.body.removeChild(dummy);
+        resolve(url);
+      } else {
+        reject(new Error("Your browser does not support copying to the clipboard."));
+      }
+    });
+  }
+
+  render() {
+    return html`
+    <!-- icon slot -->
+    ${!this.noIcon ? html`
+      <div class="pfe-clipboard__icon">
+          <slot name="icon" id="icon">
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 15.277 16"><g transform="translate(-2.077 -1.807)"><path class="a" d="M15.34,2.879a3.86,3.86,0,0,0-5.339,0L6.347,6.545a3.769,3.769,0,0,0,0,5.339.81.81,0,0,0,1.132,0,.823.823,0,0,0,0-1.145A2.144,2.144,0,0,1,7.5,7.677l3.641-3.654a2.161,2.161,0,1,1,3.049,3.062l-.8.8a.811.811,0,1,0,1.145,1.132l.8-.8a3.769,3.769,0,0,0,0-5.339Z" transform="translate(0.906 0)"/><path class="a" d="M10.482,6.822a.823.823,0,0,0,0,1.145,2.161,2.161,0,0,1,0,3.049L7.343,14.155a2.161,2.161,0,0,1-3.062,0,2.187,2.187,0,0,1,0-3.062l.193-.116a.823.823,0,0,0,0-1.145.811.811,0,0,0-1.132,0l-.193.193a3.86,3.86,0,0,0,0,5.339,3.86,3.86,0,0,0,5.339,0l3.126-3.139A3.731,3.731,0,0,0,12.72,9.562a3.769,3.769,0,0,0-1.094-2.74A.823.823,0,0,0,10.482,6.822Z" transform="translate(0 1.37)"/></g></svg>
+          </slot>
+      </div>
+    ` : ""}
+    <div class="pfe-clipboard__text">
+      <slot name="text" id="text">Copy URL</slot>
+    </div>
+    <div class="pfe-clipboard__text--success" role="alert">
+      <slot name="text--success" id="text--success">Copied</slot>
+    </div>
+    `;
+  }
+}
+
+PFElement.create(PfeClipboard);

--- a/elements/pfe-clipboard/src/pfe-clipboard.ts
+++ b/elements/pfe-clipboard/src/pfe-clipboard.ts
@@ -56,16 +56,20 @@ export class PfeClipboard extends PFElement {
       noIcon: {
         title: "No icon",
         type: Boolean,
+        attribute: "no-icon"
       },
       copiedDuration: {
         title: "Success message duration (in seconds)",
         type: Number,
+        attribute: "copied-duration"
       },
       role: {
         type: String,
+        reflect: true
       },
       tabindex: {
         type: Number,
+        reflect: true
       },
     };
   }
@@ -75,7 +79,7 @@ export class PfeClipboard extends PFElement {
     this.noIcon = false;
     this.copiedDuration = 3;
     this.copiedDuration = 3;
-    this.role = 'button';
+    this.role = "button";
     this.tabindex = 0;
   }
 
@@ -91,7 +95,6 @@ export class PfeClipboard extends PFElement {
   disconnectedCallback() {
     this.removeEventListener("click", this._clickHandler.bind(this));
     this.removeEventListener("keydown", this._keydownHandler.bind(this));
-    this.shadowRoot.removeEventListener("slotchange", this._slotchangeHandler.bind(this));
     super.disconnectedCallback();
   }
 

--- a/elements/pfe-clipboard/test/pfe-clipboard.spec.js
+++ b/elements/pfe-clipboard/test/pfe-clipboard.spec.js
@@ -1,0 +1,14 @@
+import { expect } from "@open-wc/testing/index-no-side-effects";
+import { createFixture } from "../../../test/utils/create-fixture";
+import { PfeElement } from "../dist/pfe-clipboard.js";
+
+const element = `
+  <pfe-clipboard></pfe-clipboard>
+`;
+
+describe("<pfe-clipboard>", () => {
+  it("should upgrade", async () => {
+    const el = await createFixture(element);
+    expect(el).to.be.an.instanceOf(customElements.get(PfeClipboard.tag), "pfe-clipboard should be an instance of PfeClipboard");
+  });
+});

--- a/elements/pfe-clipboard/test/pfe-clipboard.spec.js
+++ b/elements/pfe-clipboard/test/pfe-clipboard.spec.js
@@ -1,14 +1,149 @@
-import { expect } from "@open-wc/testing/index-no-side-effects";
+import { expect, elementUpdated } from "@open-wc/testing/index-no-side-effects";
+import { spy } from "sinon";
 import { createFixture } from "../../../test/utils/create-fixture";
-import { PfeElement } from "../dist/pfe-clipboard.js";
+import { PfeClipboard } from "../dist/pfe-clipboard.js";
+
+const hexToRgb = hex => {
+  const [, r, g, b] = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})/.exec(hex);
+    return [
+        parseInt(r, 16),
+        parseInt(g, 16),
+        parseInt(b, 16)
+      ];
+};
+
+const slots = {
+  icon: {
+      name: "icon",
+      class: "pfe-clipboard__icon",
+      defaultContent: `<svgxmlns="http://www.w3.org/2000/svg"width="16"height="16"viewBox="0015.27716"><gtransform="translate(-2.077-1.807)"><pathclass="a"d="M15.34,2.879a3.86,3.86,0,0,0-5.339,0L6.347,6.545a3.769,3.769,0,0,0,0,5.339.81.81,0,0,0,1.132,0,.823.823,0,0,0,0-1.145A2.144,2.144,0,0,1,7.5,7.677l3.641-3.654a2.161,2.161,0,1,1,3.049,3.062l-.8.8a.811.811,0,1,0,1.145,1.132l.8-.8a3.769,3.769,0,0,0,0-5.339Z"transform="translate(0.9060)"></path><pathclass="a"d="M10.482,6.822a.823.823,0,0,0,0,1.145,2.161,2.161,0,0,1,0,3.049L7.343,14.155a2.161,2.161,0,0,1-3.062,0,2.187,2.187,0,0,1,0-3.062l.193-.116a.823.823,0,0,0,0-1.145.811.811,0,0,0-1.132,0l-.193.193a3.86,3.86,0,0,0,0,5.339,3.86,3.86,0,0,0,5.339,0l3.126-3.139A3.731,3.731,0,0,0,12.72,9.562a3.769,3.769,0,0,0-1.094-2.74A.823.823,0,0,0,10.482,6.822Z"transform="translate(01.37)"></path></g></svg>`
+  },
+  text: {
+      name: "text",
+      class: "pfe-clipboard__text",
+      defaultContent: "Copy URL"
+  },
+  textSuccess: {
+      name: "text--success",
+      class: "pfe-clipboard__text--success",
+      defaultContent: "Copied"
+  }
+}
 
 const element = `
   <pfe-clipboard></pfe-clipboard>
 `;
 
-describe("<pfe-clipboard>", () => {
+describe("<pfe-clipboard>", async () => {
   it("should upgrade", async () => {
     const el = await createFixture(element);
     expect(el).to.be.an.instanceOf(customElements.get(PfeClipboard.tag), "pfe-clipboard should be an instance of PfeClipboard");
+  });
+
+  it("should render the default slot content.", async () => {
+    const el = await createFixture(element);
+    expect(el.shadowRoot.querySelector(`#text`).textContent).to.equal(slots.text.defaultContent);
+    expect(el.shadowRoot.querySelector(`#text--success`).textContent).to.equal(slots.textSuccess.defaultContent);
+    expect(el.shadowRoot.querySelector(`#icon`).innerHTML.replace(/\s/g, "")).to.equal(slots.icon.defaultContent);
+  });
+
+  it("it should render slot overrides", async () => {
+    const el = await createFixture(element);
+    // The default slot override will be handled by transposeSlot
+    const defaultSlot = `<span slot="text">You can totally click to copy url</span>`;
+    const textSuccessSlot = `<span slot="text--success">Making some copies!</span>`;
+    const iconSlot = `<pfe-icon slot="icon" icon="web-icon-globe" color="darker"></pfe-icon>`;
+    el.innerHTML = `
+        ${defaultSlot}
+        ${textSuccessSlot}
+        ${iconSlot}
+    `;
+    // transposeSlot should have sent it to the text named slot
+    expect(el.shadowRoot.querySelector(`#text`).assignedNodes({ flatten: true }).map(i => i.outerHTML.trim()).join("")).to.equal(defaultSlot);
+    // The text--success and icon slots should be working as expected also
+    expect(el.shadowRoot.querySelector(`#text--success`).assignedNodes({ flatten: true }).map(i => i.outerHTML.trim()).join("")).to.equal(textSuccessSlot);
+    expect(el.shadowRoot.querySelector(`#icon`).assignedNodes({ flatten: true }).map(i => i.outerHTML.trim()).join("")).to.equal(iconSlot);
+  });
+
+  it(`should hide the icon when the no-icon attribute set.`, async () => {
+    const el = await createFixture(element);
+    // Activate the no-icon boolean property
+    el.setAttribute("no-icon", true);
+    // wait for setAttribute to apply
+    await elementUpdated(el);
+    expect(el.shadowRoot.querySelector(`#icon`)).to.equal(null);
+  });
+
+  it(`should have the correct text color settings for both copied and non-copied states`, async () => {
+    const el = await createFixture(element);
+    // Default text should be set the link variable
+    expect(getComputedStyle(el.shadowRoot.querySelector(`.pfe-clipboard__text`), null)["color"]).to.equal(`rgb(${hexToRgb("#0066cc").join(', ')})`);
+    // Default text should be set the feedback--success variable
+    expect(getComputedStyle(el.shadowRoot.querySelector(`.pfe-clipboard__text--success`), null)["color"]).to.equal(`rgb(${hexToRgb("#3e8635").join(', ')})`);
+  });
+
+  it('should fire a pfe-clipboard:copied event when clicked', async () => {
+    const el = await createFixture(element);
+    const handlerSpy = spy();
+    window.focus();
+    // Add global event listener for the copy event
+    document.querySelector("body").addEventListener('pfe-clipboard:copied', handlerSpy);
+    // Simulate click
+    el.click();
+    await elementUpdated(el);
+    // Get the event from the event listener callback
+    const [event] = handlerSpy.getCall(0).args;
+    // Make sure it was called only once
+    expect(handlerSpy.calledOnce).to.be.true;
+    expect(event.detail.url).to.not.be.empty;
+    document.removeEventListener("pfe-clipboard:click", handlerSpy);
+  });
+
+  it(`should have the correct accessibility attributes`, async () => {
+    const el = await createFixture(element);
+    // Add global event listener for the copy event
+    expect(el.getAttribute("role")).to.equal("button");
+    expect(el.getAttribute("tabindex")).to.equal("0");
+  });
+
+  it(`it should display the text--success state for 3 seconds`, async () => {
+    const el = await createFixture(element);
+    el.click();
+    await elementUpdated(el);
+    // There should be a copied attribute on the host
+    expect(el.hasAttribute("copied")).to.equal(true);
+    // The text should be hidden
+    expect(getComputedStyle(el.shadowRoot.querySelector(`.pfe-clipboard__text`), null)["display"]).to.equal("none");
+    // The text--success should be visible
+    expect(getComputedStyle(el.shadowRoot.querySelector(`.pfe-clipboard__text--success`), null)["display"]).to.equal("block");
+    // @todo find out how to wait for these timeout tests
+    // after 3 seconds it should return to normal
+    //     setTimeout(() => {
+    //         // There should be a copied attribute on the host
+    //         assert.equal(clipboardStylesTest.hasAttribute("copied"), false);
+    //         // The text should be hidden
+    //         assert.equal(getComputedStyle(clipboardStylesTest.shadowRoot.querySelector(`.pfe-clipboard__text`), null)["display"], "block");
+    //         // The text--success should be visible
+    //         assert.equal(getComputedStyle(clipboardStylesTest.shadowRoot.querySelector(`.pfe-clipboard__text--success`), null)["display"], "none");
+    //         done();
+    //     }, 3001);
+  });
+
+  it(`should have a customizable copied state duration.`, async () => {
+    const el = await createFixture(element);
+    el.setAttribute("copied-duration", "1");
+    await elementUpdated(el);
+    // Set the copied state duration to 1 second
+    el.click();
+    await elementUpdated(el);
+    // @todo find out how to wait for these timeout tests
+    // Check to see if the success text
+    // setTimeout(() => {
+    //   expect(getComputedStyle(el.shadowRoot.querySelector(`.pfe-clipboard__text--success`), null)["display"]).to.equal("block");
+    // }, 0);
+    // setTimeout(() => {
+    //   expect(getComputedStyle(el.shadowRoot.querySelector(`.pfe-clipboard__text--success`), null)["display"]).to.equal("none");
+    //   done();
+    // }, 1500);
   });
 });

--- a/generators/patternfly-element-generator/index.js
+++ b/generators/patternfly-element-generator/index.js
@@ -132,7 +132,10 @@ module.exports = class extends Generator {
     }
   }
 
-  end() {
-    this.spawnCommand("npm", ["run", "build"]);
+  async end() {
+    // link the node_modules to the new directory
+    await this.spawnCommand("npm", ["run", "link"]);
+    // re-run the build step
+    await this.spawnCommand("npm", ["run", "build"]);
   }
 }

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
       </pfe-card>
     </template>
     <script type="module">
-      const elements = ["pfe-avatar", "pfe-badge", "pfe-button", "pfe-card", "pfe-cta", "pfe-datetime"];
+      const elements = ["pfe-avatar", "pfe-badge", "pfe-button", "pfe-card", "pfe-cta", "pfe-clipboard", "pfe-datetime"];
       const elementsContainer = document.getElementById("elements-container");
       const fragment = document.createDocumentFragment();
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test:watch": "npm config set group=default && npm config set element=\"*\" && web-test-runner \"elements/*/test/$npm_config_element.spec.js\" --node-resolve --playwright --watch --group=$npm_config_group",
     "test:ci": "web-test-runner --node-resolve --playwright",
     "bootstrap": "lerna bootstrap --hoist",
+    "link": "lerna link",
     "new": "yo ./generators/patternfly-element-generator"
   },
   "type": "module",


### PR DESCRIPTION
Pretty much a 1:1 port.  

I did need to comment out some of the setTimeout tests until I find out how to do them using the new testing framework.

I added `lerna link` to package.json and to the generator.  If we don't run lerna link after creating the new component then the web-dev-server won't resolve it's packages correctly.